### PR TITLE
feat(help): ship help centre pages + JSON5 index build + my-rides dee…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,8 @@
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
         "autoprefixer": "^10.4.21",
+        "chokidar-cli": "^3.0.0",
+        "concurrently": "^9.2.0",
         "eslint": "^9.25.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
@@ -2784,6 +2786,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2979,6 +2994,18 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -3154,6 +3181,211 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar-cli": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar-cli/-/chokidar-cli-3.0.0.tgz",
+      "integrity": "sha512-xVW+Qeh7z15uZRxHOkP93Ux8A0xbPzwK4GaqD8dQOYc34TlkqUhVSS59fK36DOp5WdJlrRzlYSy02Ht99FjZqQ==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "yargs": "^13.3.0"
+      },
+      "bin": {
+        "chokidar": "index.js"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/chokidar-cli/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "node_modules/chokidar-cli/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/chrome-launcher": {
       "version": "0.13.4",
@@ -3355,6 +3587,166 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.0.tgz",
+      "integrity": "sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/concurrently/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/concurrently/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/concurrently/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/configstore": {
       "version": "5.0.1",
@@ -5076,6 +5468,18 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -5635,10 +6039,22 @@
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "dev": true
     },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
       "dev": true
     },
     "node_modules/lookup-closest-locale": {
@@ -5909,6 +6325,15 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/normalize-range": {
       "version": "0.1.2",
@@ -6732,6 +7157,18 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7064,6 +7501,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -5,15 +5,18 @@
   "homepage": "/",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "concurrently -k -n VITE,HELP \"vite\" \"npm:dev:help-index:watch\"",
     "start": "vite",
     "build": "vite build",
     "deploy": "gh-pages -d dist",
+    "build:help-index": "node scripts/stripHelpIndex.mjs",
+    "dev:help-index:watch": "chokidar \"src/Pages/Help/help-index.dev.json5\" --initial --verbose --poll=1000 --await-write-finish=500 -c \"npm run build:help-index\"",
     "lint": "eslint .",
     "preview": "vite preview --host --port 4173 --strictPort",
     "type-check": "tsc --noEmit",
     "type-check:node": "tsc --noEmit -p tsconfig.node.json",
-    "backfill:coords": "node scripts/backfill-ride-coords.mjs"
+    "backfill:coords": "node scripts/backfill-ride-coords.mjs",
+    "prebuild": "npm run build:help-index"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -50,6 +53,8 @@
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
     "autoprefixer": "^10.4.21",
+    "chokidar-cli": "^3.0.0",
+    "concurrently": "^9.2.0",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -1,92 +1,233 @@
-[
-  {
-    "title": "Rating your carpool driver",
-    "path": "/help/rating-driver",
-    "category": "driver",
-    "tags": ["rating", "review", "driver", "feedback"],
-    "popular": true
-  },
-  {
-    "title": "Offering a ride",
-    "path": "/help/offering-ride",
-    "category": "driver",
-    "tags": ["offer", "ride", "publish"]
-  },
-
-  {
-    "title": "Passenger cancellation rate",
-    "path": "/help/passenger-cancellation",
-    "category": "passenger",
-    "tags": ["cancellation", "penalties", "no show", "policy"],
-    "popular": true
-  },
-
-  {
-    "title": "Search Tips",
-    "path": "/help/passenger/search-tips",
-    "category": "passenger",
-    "tags": ["search", "filters", "find", "results"]
-  },
-  {
-    "title": "How to Book",
-    "path": "/help/passenger/how-to-book",
-    "category": "passenger",
-    "tags": ["booking", "request", "join", "confirmation"]
-  },
-  {
-    "title": "Requirements to Book",
-    "path": "/help/passenger/requirements",
-    "category": "passenger",
-    "tags": ["signup", "profile", "verification", "eligibility"]
-  },
-  {
-    "title": "Booking Requests & Confirmation",
-    "path": "/help/passenger/booking-confirmation",
-    "category": "passenger",
-    "tags": ["confirmation", "email", "accepted", "rejected"]
-  },
-  {
-    "title": "Communicating with Drivers",
-    "path": "/help/passenger/communicating-drivers",
-    "category": "passenger",
-    "tags": ["chat", "message", "coordination", "host"]
-  },
-  {
-    "title": "Luggage Guidelines",
-    "path": "/help/passenger/luggage",
-    "category": "passenger",
-    "tags": ["bags", "weight", "limits", "baggage"]
-  },
-
-  {
-    "title": "Paying for a Ride",
-    "path": "/help/passenger/payment-methods",
-    "category": "account",
-    "tags": ["payment", "pre-pay", "deep link", "payment methods"]
-  },
-  {
-    "title": "Pricing",
-    "path": "/help/passenger/pricing",
-    "category": "account",
-    "tags": ["pricing", "fare", "cost"]
-  },
-  {
-    "title": "Refunds and Exchanges",
-    "path": "/help/passenger/refunds",
-    "category": "account",
-    "tags": ["refund", "exchange", "cancel", "reimbursement"]
-  },
-  {
-    "title": "Invoices and Receipts",
-    "path": "/help/passenger/invoices",
-    "category": "account",
-    "tags": ["invoice", "receipt", "pre-pay"]
-  },
-
-  {
-    "title": "Accessibility features",
-    "path": "/help/accessibility",
-    "category": "safety",
-    "tags": ["a11y", "screen reader", "vision"]
-  }
-]
+{
+  "_comment": "⚠️ AUTO-GENERATED from help-index.dev.json5 — DO NOT EDIT",
+  "items": [
+    {
+      "title": "Rating your carpool driver",
+      "path": "/help/rating-driver",
+      "category": "driver",
+      "tags": [
+        "rating",
+        "review",
+        "driver",
+        "feedback"
+      ],
+      "popular": true
+    },
+    {
+      "title": "Offering a ride",
+      "path": "/help/offering-ride",
+      "category": "driver",
+      "tags": [
+        "offer",
+        "ride",
+        "publish"
+      ]
+    },
+    {
+      "title": "Passenger cancellation rate",
+      "path": "/help/passenger-cancellation",
+      "category": "passenger",
+      "tags": [
+        "cancellation",
+        "penalties",
+        "no show",
+        "policy"
+      ],
+      "popular": true
+    },
+    {
+      "title": "Search Tips",
+      "path": "/help/passenger/search-tips",
+      "category": "passenger",
+      "tags": [
+        "search",
+        "filters",
+        "find",
+        "results"
+      ]
+    },
+    {
+      "title": "How to Book",
+      "path": "/help/passenger/how-to-book",
+      "category": "passenger",
+      "tags": [
+        "booking",
+        "request",
+        "join",
+        "confirmation"
+      ]
+    },
+    {
+      "title": "Requirements to Book",
+      "path": "/help/passenger/requirements",
+      "category": "passenger",
+      "tags": [
+        "signup",
+        "profile",
+        "verification",
+        "eligibility"
+      ]
+    },
+    {
+      "title": "Booking Requests & Confirmation",
+      "path": "/help/passenger/booking-confirmation",
+      "category": "passenger",
+      "tags": [
+        "confirmation",
+        "email",
+        "accepted",
+        "rejected"
+      ]
+    },
+    {
+      "title": "Communicating with Drivers",
+      "path": "/help/passenger/communicating-drivers",
+      "category": "passenger",
+      "tags": [
+        "chat",
+        "message",
+        "coordination",
+        "host"
+      ]
+    },
+    {
+      "title": "Luggage Guidelines",
+      "path": "/help/passenger/luggage",
+      "category": "passenger",
+      "tags": [
+        "bags",
+        "weight",
+        "limits",
+        "baggage"
+      ]
+    },
+    {
+      "title": "Paying for a Ride",
+      "path": "/help/passenger/payment-methods",
+      "category": "account",
+      "tags": [
+        "payment",
+        "pre-pay",
+        "deep link",
+        "payment methods"
+      ]
+    },
+    {
+      "title": "Pricing",
+      "path": "/help/passenger/pricing",
+      "category": "account",
+      "tags": [
+        "pricing",
+        "fare",
+        "cost"
+      ]
+    },
+    {
+      "title": "Refunds and Exchanges",
+      "path": "/help/passenger/refunds",
+      "category": "account",
+      "tags": [
+        "refund",
+        "exchange",
+        "cancel",
+        "reimbursement"
+      ]
+    },
+    {
+      "title": "Invoices and Receipts",
+      "path": "/help/passenger/invoices",
+      "category": "account",
+      "tags": [
+        "invoice",
+        "receipt",
+        "pre-pay"
+      ]
+    },
+    {
+      "title": "How to Find Your Booking",
+      "path": "/help/passenger/find-booking",
+      "category": "passenger",
+      "tags": [
+        "booking",
+        "my rides",
+        "upcoming",
+        "find"
+      ]
+    },
+    {
+      "title": "Cancellations",
+      "path": "/help/passenger/cancellations",
+      "category": "passenger",
+      "tags": [
+        "cancel",
+        "48 hours",
+        "policy"
+      ]
+    },
+    {
+      "title": "How to Change Your Booking",
+      "path": "/help/passenger/change-booking",
+      "category": "passenger",
+      "tags": [
+        "change",
+        "edit",
+        "modify",
+        "host"
+      ]
+    },
+    {
+      "title": "Preparing to Travel",
+      "path": "/help/passenger/preparing-travel",
+      "category": "passenger",
+      "tags": [
+        "prepare",
+        "checklist",
+        "pickup",
+        "notifications"
+      ]
+    },
+    {
+      "title": "Post-ride",
+      "path": "/help/passenger/post-ride",
+      "category": "passenger",
+      "tags": [
+        "review",
+        "feedback",
+        "after"
+      ]
+    },
+    {
+      "title": "Lost Item in Ride",
+      "path": "/help/passenger/lost-item",
+      "category": "passenger",
+      "tags": [
+        "lost",
+        "found",
+        "support",
+        "contact"
+      ]
+    },
+    {
+      "title": "Troubleshooting",
+      "path": "/help/passenger/troubleshooting",
+      "category": "passenger",
+      "tags": [
+        "issues",
+        "not showing",
+        "edit",
+        "chat"
+      ]
+    },
+    {
+      "title": "Accessibility features",
+      "path": "/help/accessibility",
+      "category": "safety",
+      "tags": [
+        "a11y",
+        "screen reader",
+        "vision"
+      ]
+    }
+  ],
+  "generatedAt": "2025-08-18T16:25:25.365Z"
+}

--- a/scripts/stripHelpIndex.mjs
+++ b/scripts/stripHelpIndex.mjs
@@ -1,0 +1,62 @@
+// scripts/stripHelpIndex.mjs
+import JSON5 from "json5";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const root = process.cwd();
+
+// Try these locations in order; stops at the first that exists
+const candidateInputs = [
+  "src/Pages/Help/help-index.dev.json5",
+  "Pages/Help/help-index.dev.json5",
+  "src/help/help-index.dev.json5",
+  "src/data/help/help-index.dev.json5",
+];
+
+async function findInputFile() {
+  for (const rel of candidateInputs) {
+    const abs = path.join(root, rel);
+    try {
+      await fs.access(abs);
+      if (process.env.DEBUG_HELP_INDEX) {
+        console.log(`(debug) ✅ found dev index at: ${abs}`);
+      }
+      return abs;
+    } catch (err) {
+      if (process.env.DEBUG_HELP_INDEX) {
+        console.warn(
+          `(debug) not found: ${abs} (${err?.code || err?.message})`
+        );
+      }
+    }
+  }
+  return null;
+}
+
+const inputFile = await findInputFile();
+if (!inputFile) {
+  console.error("❌ Could not find help-index.dev.json5. Looked in:");
+  candidateInputs.forEach((p) => console.error("   -", path.join(root, p)));
+  process.exit(1);
+}
+
+const outputFile = path.join(root, "public/help-index.json");
+
+try {
+  console.log(`🔎 Reading: ${inputFile}`);
+  const devJson = await fs.readFile(inputFile, "utf-8");
+  const parsed = JSON5.parse(devJson);
+
+  const withComment = {
+    _comment: "⚠️ AUTO-GENERATED from help-index.dev.json5 — DO NOT EDIT",
+    items: parsed,
+    generatedAt: new Date().toISOString(),
+  };
+
+  await fs.writeFile(outputFile, JSON.stringify(withComment, null, 2));
+  console.log(`✅ Wrote: ${outputFile}`);
+} catch (err) {
+  console.error("❌ Failed to build help-index.json");
+  console.error(err?.stack || err?.message || err);
+  process.exit(1);
+}

--- a/src/Pages/Help/Help.jsx
+++ b/src/Pages/Help/Help.jsx
@@ -100,7 +100,6 @@ export default function HelpPage() {
   const navigate = useNavigate();
 
   // Fetch the help index once
-
   useEffect(() => {
     let alive = true;
     (async () => {
@@ -112,7 +111,20 @@ export default function HelpPage() {
         const ct = res.headers.get("content-type") || "";
         if (!ct.includes("application/json")) throw new Error("Not JSON");
         const data = await res.json();
-        if (alive) setIndexItems(Array.isArray(data) ? data : []);
+
+        // Support both legacy array and new wrapped { items: [...] } shape
+        const items = Array.isArray(data)
+          ? data
+          : Array.isArray(data?.items)
+            ? data.items
+            : [];
+
+        if (alive) setIndexItems(items);
+        if (!Array.isArray(data) && !Array.isArray(data?.items)) {
+          console.warn(
+            "help-index.json did not contain an array or an {items: []} object; falling back to empty list."
+          );
+        }
       } catch (e) {
         if (alive) {
           console.error("help-index.json load failed:", e);
@@ -241,7 +253,6 @@ export default function HelpPage() {
       </Helmet>
 
       {/* Top Header */}
-
       <header className="help-header">
         <h1>How can we help?</h1>
 
@@ -250,6 +261,8 @@ export default function HelpPage() {
           setQ={setQ}
           results={results}
           renderTitle={(title) => <Highlight text={title} query={q} />}
+          inputRef={inputRef}
+          onSubmit={onSubmit}
         />
       </header>
 

--- a/src/Pages/Help/Passenger/YourBookings/Cancellations.jsx
+++ b/src/Pages/Help/Passenger/YourBookings/Cancellations.jsx
@@ -1,5 +1,13 @@
-import React from "react";
+import { Helmet } from "react-helmet-async";
 import HelpArticleLayout from "../../HelpArticleLayout";
+
+const page = {
+  title: "Cancellations — TabFair",
+  description: "Understand when and how bookings can be cancelled.",
+  canonical: "https://www.tabfair.com/help/passenger/cancellations",
+  published: "2025-08-18",
+  modified: "2025-08-18",
+};
 
 export default function Cancellations() {
   const breadcrumb = [
@@ -8,30 +16,50 @@ export default function Cancellations() {
     { label: "Cancellations" },
   ];
 
+  const webPageLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: page.title,
+    description: page.description,
+    url: page.canonical,
+    inLanguage: "en-GB",
+    datePublished: page.published,
+    dateModified: page.modified,
+  };
+
   return (
-    <HelpArticleLayout
-      title="Cancellations"
-      description="Understand when and how bookings can be cancelled."
-      breadcrumb={breadcrumb}
-    >
-      <ul>
-        <li>
-          You can cancel a booking up to{" "}
-          <strong>48 hours before departure</strong>.
-        </li>
-        <li>
-          Cancellations within 48h may still incur charges unless all users
-          agree.
-        </li>
-        <li>
-          If all users mutually agree, you can cancel after 48h—but cancellation
-          rules still apply.
-        </li>
-      </ul>
-      <p>
-        All cancellations are managed via your{" "}
-        <strong>My Rides → Upcoming Rides</strong> page.
-      </p>
-    </HelpArticleLayout>
+    <>
+      <Helmet>
+        <title>{page.title}</title>
+        <meta name="description" content={page.description} />
+        <link rel="canonical" href={page.canonical} />
+        <script type="application/ld+json">{JSON.stringify(webPageLd)}</script>
+      </Helmet>
+
+      <HelpArticleLayout
+        title="Cancellations"
+        description="Understand when and how bookings can be cancelled."
+        breadcrumb={breadcrumb}
+      >
+        <ul>
+          <li>
+            You can cancel a booking up to{" "}
+            <strong>48 hours before departure</strong>.
+          </li>
+          <li>
+            Cancellations within 48h may still incur charges unless all users
+            agree.
+          </li>
+          <li>
+            If all users mutually agree, you can cancel after 48h—but
+            cancellation rules still apply.
+          </li>
+        </ul>
+        <p>
+          All cancellations are managed via your{" "}
+          <strong>My Rides → Upcoming Rides</strong> page.
+        </p>
+      </HelpArticleLayout>
+    </>
   );
 }

--- a/src/Pages/Help/Passenger/YourBookings/ChangeBooking.jsx
+++ b/src/Pages/Help/Passenger/YourBookings/ChangeBooking.jsx
@@ -1,5 +1,13 @@
-import React from "react";
+import { Helmet } from "react-helmet-async";
 import HelpArticleLayout from "../../HelpArticleLayout";
+
+const page = {
+  title: "How to Change Your Booking — TabFair",
+  description: "Options for modifying rides you’ve created or booked.",
+  canonical: "https://www.tabfair.com/help/passenger/change-booking",
+  published: "2025-08-18",
+  modified: "2025-08-18",
+};
 
 export default function ChangeBooking() {
   const breadcrumb = [
@@ -8,34 +16,54 @@ export default function ChangeBooking() {
     { label: "How to Change Your Booking" },
   ];
 
-  return (
-    <HelpArticleLayout
-      title="How to Change Your Booking"
-      description="Options for modifying rides you’ve created or booked."
-      breadcrumb={breadcrumb}
-    >
-      <h2>If you posted a ride:</h2>
-      <ul>
-        <li>
-          You can edit your ride via{" "}
-          <strong>My Rides → Published Rides → Edit</strong>.
-        </li>
-        <li>
-          Changes are allowed up to <strong>48 hours before departure</strong>{" "}
-          and only if no one has joined yet.
-        </li>
-      </ul>
+  const webPageLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: page.title,
+    description: page.description,
+    url: page.canonical,
+    inLanguage: "en-GB",
+    datePublished: page.published,
+    dateModified: page.modified,
+  };
 
-      <h2>If you booked someone else’s ride:</h2>
-      <ul>
-        <li>
-          You can cancel up to <strong>48 hours before departure</strong>.
-        </li>
-        <li>
-          For changes beyond that—like adjusting times—please message the ride
-          host directly via the chat feature.
-        </li>
-      </ul>
-    </HelpArticleLayout>
+  return (
+    <>
+      <Helmet>
+        <title>{page.title}</title>
+        <meta name="description" content={page.description} />
+        <link rel="canonical" href={page.canonical} />
+        <script type="application/ld+json">{JSON.stringify(webPageLd)}</script>
+      </Helmet>
+
+      <HelpArticleLayout
+        title="How to Change Your Booking"
+        description="Options for modifying rides you’ve created or booked."
+        breadcrumb={breadcrumb}
+      >
+        <h2>If you posted a ride:</h2>
+        <ul>
+          <li>
+            You can edit your ride via{" "}
+            <strong>My Rides → Published Rides → Edit</strong>.
+          </li>
+          <li>
+            Changes are allowed up to <strong>48 hours before departure</strong>{" "}
+            and only if no one has joined yet.
+          </li>
+        </ul>
+
+        <h2>If you booked someone else’s ride:</h2>
+        <ul>
+          <li>
+            You can cancel up to <strong>48 hours before departure</strong>.
+          </li>
+          <li>
+            For changes beyond that—like adjusting times—please message the ride
+            host directly via the chat feature.
+          </li>
+        </ul>
+      </HelpArticleLayout>
+    </>
   );
 }

--- a/src/Pages/Help/Passenger/YourBookings/FindBooking.jsx
+++ b/src/Pages/Help/Passenger/YourBookings/FindBooking.jsx
@@ -1,5 +1,16 @@
-import React from "react";
+// src/Pages/FindBooking.jsx
+import { Helmet } from "react-helmet-async";
+import { Link } from "react-router-dom";
 import HelpArticleLayout from "../../HelpArticleLayout";
+
+const page = {
+  title: "How to Find Your Booking — TabFair",
+  description:
+    "Locate upcoming and recent rides easily in the My Rides dashboard.",
+  canonical: "https://www.tabfair.com/help/passenger/find-booking",
+  published: "2025-08-18",
+  modified: "2025-08-18",
+};
 
 export default function FindBooking() {
   const breadcrumb = [
@@ -8,26 +19,47 @@ export default function FindBooking() {
     { label: "How to Find Your Booking" },
   ];
 
+  const webPageLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: page.title,
+    description: page.description,
+    url: page.canonical,
+    inLanguage: "en-GB",
+    datePublished: page.published,
+    dateModified: page.modified,
+  };
+
   return (
-    <HelpArticleLayout
-      title="How to Find Your Booking"
-      description="Locate upcoming and recent rides easily in the My Rides dashboard."
-      breadcrumb={breadcrumb}
-    >
-      <ol>
-        <li>Log in to your Tabfair account.</li>
-        <li>
-          Click the menu in the top-right corner and select{" "}
-          <strong>My Rides</strong>.
-        </li>
-        <li>
-          Go to the <strong>Upcoming Rides</strong> tab to see your bookings.
-        </li>
-      </ol>
-      <p>
-        If a booking is missing, double-check your confirmation email or refresh
-        your My Rides page.
-      </p>
-    </HelpArticleLayout>
+    <>
+      <Helmet>
+        <title>{page.title}</title>
+        <meta name="description" content={page.description} />
+        <link rel="canonical" href={page.canonical} />
+        <script type="application/ld+json">{JSON.stringify(webPageLd)}</script>
+      </Helmet>
+
+      <HelpArticleLayout
+        title="How to Find Your Booking"
+        description="Locate upcoming and recent rides easily in the My Rides dashboard."
+        breadcrumb={breadcrumb}
+      >
+        <ol>
+          <li>Log in to your Tabfair account.</li>
+          <li>
+            Click the menu in the top-right corner and select{" "}
+            <Link to="/my-rides">My Rides</Link>.
+          </li>
+          <li>
+            Go to the <Link to="/my-rides?tab=booked">Booked Rides</Link> tab to
+            see your bookings.
+          </li>
+        </ol>
+        <p>
+          If a booking is missing, double-check your confirmation email or
+          refresh your My Rides page.
+        </p>
+      </HelpArticleLayout>
+    </>
   );
 }

--- a/src/Pages/Help/Passenger/YourBookings/LostItem.jsx
+++ b/src/Pages/Help/Passenger/YourBookings/LostItem.jsx
@@ -1,5 +1,13 @@
-import React from "react";
+import { Helmet } from "react-helmet-async";
 import HelpArticleLayout from "../../HelpArticleLayout";
+
+const page = {
+  title: "Lost Item in Ride — TabFair",
+  description: "Steps to take if you left something behind in the taxi.",
+  canonical: "https://www.tabfair.com/help/passenger/lost-item",
+  published: "2025-08-18",
+  modified: "2025-08-18",
+};
 
 export default function LostItem() {
   const breadcrumb = [
@@ -8,32 +16,53 @@ export default function LostItem() {
     { label: "Lost Item in Ride" },
   ];
 
+  const webPageLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: page.title,
+    description: page.description,
+    url: page.canonical,
+    inLanguage: "en-GB",
+    datePublished: page.published,
+    dateModified: page.modified,
+  };
+
   return (
-    <HelpArticleLayout
-      title="Lost Item in Ride"
-      description="Steps to take if you left something behind in the taxi."
-      breadcrumb={breadcrumb}
-    >
-      <p>If you lost an item during your shared taxi ride:</p>
+    <>
+      <Helmet>
+        <title>{page.title}</title>
+        <meta name="description" content={page.description} />
+        <link rel="canonical" href={page.canonical} />
+        <script type="application/ld+json">{JSON.stringify(webPageLd)}</script>
+      </Helmet>
 
-      <ol>
-        <li>
-          Message your co-passenger through{" "}
-          <strong>My Rides &gt; Past Rides</strong>
-        </li>
-        <li>
-          If you used a third-party taxi provider, try contacting them directly
-          with ride time and route details
-        </li>
-        <li>
-          If urgent or no response, <a href="/help/contact">contact support</a>
-        </li>
-      </ol>
+      <HelpArticleLayout
+        title="Lost Item in Ride"
+        description="Steps to take if you left something behind in the taxi."
+        breadcrumb={breadcrumb}
+      >
+        <p>If you lost an item during your shared taxi ride:</p>
 
-      <p>
-        Always double-check the taxi before exiting. Ride partners are usually
-        happy to help if contacted quickly!
-      </p>
-    </HelpArticleLayout>
+        <ol>
+          <li>
+            Message your co-passenger through{" "}
+            <strong>My Rides &gt; Past Rides</strong>
+          </li>
+          <li>
+            If you used a third-party taxi provider, try contacting them
+            directly with ride time and route details
+          </li>
+          <li>
+            If urgent or no response,{" "}
+            <a href="/help/contact">contact support</a>
+          </li>
+        </ol>
+
+        <p>
+          Always double-check the taxi before exiting. Ride partners are usually
+          happy to help if contacted quickly!
+        </p>
+      </HelpArticleLayout>
+    </>
   );
 }

--- a/src/Pages/Help/Passenger/YourBookings/PostRide.jsx
+++ b/src/Pages/Help/Passenger/YourBookings/PostRide.jsx
@@ -1,24 +1,52 @@
-import React from "react";
+import { Helmet } from "react-helmet-async";
 import HelpArticleLayout from "../../HelpArticleLayout";
+
+const page = {
+  title: "Post-ride — TabFair",
+  description: "What to do after your shared ride ends.",
+  canonical: "https://www.tabfair.com/help/passenger/post-ride",
+  published: "2025-08-18",
+  modified: "2025-08-18",
+};
 
 export default function PostRide() {
   const breadcrumb = [
     { label: "Help", to: "/help" },
     { label: "Passenger", to: "/help/passenger" },
-    { label: "Post‑ride" },
+    { label: "Post-ride" },
   ];
 
+  const webPageLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: page.title,
+    description: page.description,
+    url: page.canonical,
+    inLanguage: "en-GB",
+    datePublished: page.published,
+    dateModified: page.modified,
+  };
+
   return (
-    <HelpArticleLayout
-      title="Post‑ride"
-      description="What to do after your shared ride ends."
-      breadcrumb={breadcrumb}
-    >
-      <ul>
-        <li>Leave a review for the passenger(s) you shared a ride with.</li>
-        <li>Provide feedback on the ride experience.</li>
-        <li>If you left an item behind, reach out quickly to retrieve it.</li>
-      </ul>
-    </HelpArticleLayout>
+    <>
+      <Helmet>
+        <title>{page.title}</title>
+        <meta name="description" content={page.description} />
+        <link rel="canonical" href={page.canonical} />
+        <script type="application/ld+json">{JSON.stringify(webPageLd)}</script>
+      </Helmet>
+
+      <HelpArticleLayout
+        title="Post-ride"
+        description="What to do after your shared ride ends."
+        breadcrumb={breadcrumb}
+      >
+        <ul>
+          <li>Leave a review for the passenger(s) you shared a ride with.</li>
+          <li>Provide feedback on the ride experience.</li>
+          <li>If you left an item behind, reach out quickly to retrieve it.</li>
+        </ul>
+      </HelpArticleLayout>
+    </>
   );
 }

--- a/src/Pages/Help/Passenger/YourBookings/PreparingToTravel.jsx
+++ b/src/Pages/Help/Passenger/YourBookings/PreparingToTravel.jsx
@@ -1,5 +1,13 @@
-import React from "react";
+import { Helmet } from "react-helmet-async";
 import HelpArticleLayout from "../../HelpArticleLayout";
+
+const page = {
+  title: "Preparing to Travel — TabFair",
+  description: "Checklist and best practices before your shared taxi ride.",
+  canonical: "https://www.tabfair.com/help/passenger/preparing-travel",
+  published: "2025-08-18",
+  modified: "2025-08-18",
+};
 
 export default function PreparingToTravel() {
   const breadcrumb = [
@@ -8,21 +16,41 @@ export default function PreparingToTravel() {
     { label: "Preparing to Travel" },
   ];
 
+  const webPageLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: page.title,
+    description: page.description,
+    url: page.canonical,
+    inLanguage: "en-GB",
+    datePublished: page.published,
+    dateModified: page.modified,
+  };
+
   return (
-    <HelpArticleLayout
-      title="Preparing to Travel"
-      description="Checklist and best practices before your shared taxi ride."
-      breadcrumb={breadcrumb}
-    >
-      <ul>
-        <li>
-          Confirm ride time and pickup location from your{" "}
-          <strong>My Rides</strong> page.
-        </li>
-        <li>Verify luggage and passenger counts.</li>
-        <li>Charge your phone and enable notifications.</li>
-        <li>Arrive 5–10 minutes early to meet your ride partner or taxi.</li>
-      </ul>
-    </HelpArticleLayout>
+    <>
+      <Helmet>
+        <title>{page.title}</title>
+        <meta name="description" content={page.description} />
+        <link rel="canonical" href={page.canonical} />
+        <script type="application/ld+json">{JSON.stringify(webPageLd)}</script>
+      </Helmet>
+
+      <HelpArticleLayout
+        title="Preparing to Travel"
+        description="Checklist and best practices before your shared taxi ride."
+        breadcrumb={breadcrumb}
+      >
+        <ul>
+          <li>
+            Confirm ride time and pickup location from your{" "}
+            <strong>My Rides</strong> page.
+          </li>
+          <li>Verify luggage and passenger counts.</li>
+          <li>Charge your phone and enable notifications.</li>
+          <li>Arrive 5–10 minutes early to meet your ride partner or taxi.</li>
+        </ul>
+      </HelpArticleLayout>
+    </>
   );
 }

--- a/src/Pages/Help/Passenger/YourBookings/Troubleshooting.jsx
+++ b/src/Pages/Help/Passenger/YourBookings/Troubleshooting.jsx
@@ -1,5 +1,13 @@
-import React from "react";
+import { Helmet } from "react-helmet-async";
 import HelpArticleLayout from "../../HelpArticleLayout";
+
+const page = {
+  title: "Troubleshooting — TabFair",
+  description: "Fix common booking and ride issues.",
+  canonical: "https://www.tabfair.com/help/passenger/troubleshooting",
+  published: "2025-08-18",
+  modified: "2025-08-18",
+};
 
 export default function Troubleshooting() {
   const breadcrumb = [
@@ -8,24 +16,45 @@ export default function Troubleshooting() {
     { label: "Troubleshooting" },
   ];
 
+  const webPageLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: page.title,
+    description: page.description,
+    url: page.canonical,
+    inLanguage: "en-GB",
+    datePublished: page.published,
+    dateModified: page.modified,
+  };
+
   return (
-    <HelpArticleLayout
-      title="Troubleshooting"
-      description="Fix common booking and ride issues."
-      breadcrumb={breadcrumb}
-    >
-      <ul>
-        <li>
-          Booking not showing? Make sure it was properly submitted and check
-          Upcoming Rides.
-        </li>
-        <li>
-          Unable to edit ride? Confirm it’s before the 48h modification window.
-        </li>
-        <li>
-          Need to message a rider? Use the in-app chat under Upcoming Rides.
-        </li>
-      </ul>
-    </HelpArticleLayout>
+    <>
+      <Helmet>
+        <title>{page.title}</title>
+        <meta name="description" content={page.description} />
+        <link rel="canonical" href={page.canonical} />
+        <script type="application/ld+json">{JSON.stringify(webPageLd)}</script>
+      </Helmet>
+
+      <HelpArticleLayout
+        title="Troubleshooting"
+        description="Fix common booking and ride issues."
+        breadcrumb={breadcrumb}
+      >
+        <ul>
+          <li>
+            Booking not showing? Make sure it was properly submitted and check
+            Upcoming Rides.
+          </li>
+          <li>
+            Unable to edit ride? Confirm it’s before the 48h modification
+            window.
+          </li>
+          <li>
+            Need to message a rider? Use the in-app chat under Upcoming Rides.
+          </li>
+        </ul>
+      </HelpArticleLayout>
+    </>
   );
 }

--- a/src/Pages/Help/help-index.dev.json5
+++ b/src/Pages/Help/help-index.dev.json5
@@ -1,0 +1,140 @@
+[
+  // === DRIVER HELP ===
+  {
+    title: "Rating your carpool driver",
+    path: "/help/rating-driver",
+    category: "driver",
+    tags: ["rating", "review", "driver", "feedback"],
+    popular: true,
+  },
+  {
+    title: "Offering a ride",
+    path: "/help/offering-ride",
+    category: "driver",
+    tags: ["offer", "ride", "publish"],
+  },
+
+  // === PASSENGER — CANCELLATION POLICY ===
+  {
+    title: "Passenger cancellation rate",
+    path: "/help/passenger-cancellation",
+    category: "passenger",
+    tags: ["cancellation", "penalties", "no show", "policy"],
+    popular: true,
+  },
+
+  // === PASSENGER — SEARCHING AND BOOKINGS ===
+  {
+    title: "Search Tips",
+    path: "/help/passenger/search-tips",
+    category: "passenger",
+    tags: ["search", "filters", "find", "results"],
+  },
+  {
+    title: "How to Book",
+    path: "/help/passenger/how-to-book",
+    category: "passenger",
+    tags: ["booking", "request", "join", "confirmation"],
+  },
+  {
+    title: "Requirements to Book",
+    path: "/help/passenger/requirements",
+    category: "passenger",
+    tags: ["signup", "profile", "verification", "eligibility"],
+  },
+  {
+    title: "Booking Requests & Confirmation",
+    path: "/help/passenger/booking-confirmation",
+    category: "passenger",
+    tags: ["confirmation", "email", "accepted", "rejected"],
+  },
+  {
+    title: "Communicating with Drivers",
+    path: "/help/passenger/communicating-drivers",
+    category: "passenger",
+    tags: ["chat", "message", "coordination", "host"],
+  },
+  {
+    title: "Luggage Guidelines",
+    path: "/help/passenger/luggage",
+    category: "passenger",
+    tags: ["bags", "weight", "limits", "baggage"],
+  },
+
+  // === PASSENGER — Payments, Pricing and Refunds ===
+  {
+    title: "Paying for a Ride",
+    path: "/help/passenger/payment-methods",
+    category: "account",
+    tags: ["payment", "pre-pay", "deep link", "payment methods"],
+  },
+  {
+    title: "Pricing",
+    path: "/help/passenger/pricing",
+    category: "account",
+    tags: ["pricing", "fare", "cost"],
+  },
+  {
+    title: "Refunds and Exchanges",
+    path: "/help/passenger/refunds",
+    category: "account",
+    tags: ["refund", "exchange", "cancel", "reimbursement"],
+  },
+  {
+    title: "Invoices and Receipts",
+    path: "/help/passenger/invoices",
+    category: "account",
+    tags: ["invoice", "receipt", "pre-pay"],
+  },
+  // === PASSENGER — YOUR BOOKINGS ===
+  {
+    title: "How to Find Your Booking",
+    path: "/help/passenger/find-booking",
+    category: "passenger",
+    tags: ["booking", "my rides", "upcoming", "find"],
+  },
+  {
+    title: "Cancellations",
+    path: "/help/passenger/cancellations",
+    category: "passenger",
+    tags: ["cancel", "48 hours", "policy"],
+  },
+  {
+    title: "How to Change Your Booking",
+    path: "/help/passenger/change-booking",
+    category: "passenger",
+    tags: ["change", "edit", "modify", "host"],
+  },
+  {
+    title: "Preparing to Travel",
+    path: "/help/passenger/preparing-travel",
+    category: "passenger",
+    tags: ["prepare", "checklist", "pickup", "notifications"],
+  },
+  {
+    title: "Post-ride",
+    path: "/help/passenger/post-ride",
+    category: "passenger",
+    tags: ["review", "feedback", "after"],
+  },
+  {
+    title: "Lost Item in Ride",
+    path: "/help/passenger/lost-item",
+    category: "passenger",
+    tags: ["lost", "found", "support", "contact"],
+  },
+  {
+    title: "Troubleshooting",
+    path: "/help/passenger/troubleshooting",
+    category: "passenger",
+    tags: ["issues", "not showing", "edit", "chat"],
+  },
+
+  // === SAFETY & ACCESSIBILITY ===
+  {
+    title: "Accessibility features",
+    path: "/help/accessibility",
+    category: "safety",
+    tags: ["a11y", "screen reader", "vision"],
+  },
+]


### PR DESCRIPTION
feat(help): add new Help pages + JSON5 index pipeline + deep-link tabs

- Add passenger help pages: Paying for a Ride, Pricing, Refunds & Exchanges,
  Invoices & Receipts, Search Tips, How to Book, Requirements, Booking Requests
  & Confirmation, Communicating with Drivers, Luggage, Find Booking,
  Cancellations, Change Booking, Preparing to Travel, Post-ride, Lost Item,
  Troubleshooting (with Helmet + JSON-LD + breadcrumbs)
- Introduce help-index.dev.json5 with comments; generate public/help-index.json
  via scripts/stripHelpIndex.mjs (ESM) + prebuild hook
- Add chokidar watcher and concurrently to auto-regenerate during `npm run dev`
- Update Help.jsx to support { items: [...] } shape and preserve legacy array
- Wire tab deep-links for /my-rides via ?tab=published|saved|booked
- Minor SEO/canonical updates and consistency across pages
